### PR TITLE
perf: set max distance based on length of string and skip if distance exceeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tiny lightweight library for Fuzzy Search.
 
 ## Why
 
-I made this library as a result of learning about [Levenshtein](https://en.wikipedia.org/wiki/Levenshtein_distance) algorithm to calculate minimum number of edits required transform one word to another.
+I made this library as a result of learning about [Levenshtein Distance](https://en.wikipedia.org/wiki/Levenshtein_distance) algorithm to calculate minimum number of edits required transform one word to another by [Vladimir Levenshtein](https://en.wikipedia.org/wiki/Vladimir_Levenshtein).
 
 > [!NOTE]  
 > Note: The library is at a very early stage, if you want to

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -1,4 +1,4 @@
-import Fuzzy from "fuzzify";
+import Fuzzy from "../src/index";
 import { Result } from "../src/Fuzzy";
 
 import { countries } from "./countries";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,8 +26,20 @@ export const levenshteinFullMatrixSearch = (query: string, target: string) => {
   }
   return dp;
 };
-// Get matching indices from the matrix
 
+// Set max distance based on the length of the strings
+export const getMaxLevenshteinDistance = (query: string, target: string) => {
+  const length = Math.max(query.length, target.length);
+  if (length <= 5) {
+    return 3;
+  }
+  if (length <= 15) {
+    return 10;
+  }
+  return 15;
+};
+
+// Get matching indices from the matrix
 export const getMatchingIndices = (
   matrix: Array<string>[],
   query: string,
@@ -58,6 +70,11 @@ export const calculateScore = (
   matches: number[][],
   distance: number
 ) => {
+  const maxLevenshteinDistance = getMaxLevenshteinDistance(query, target);
+
+  if (distance > maxLevenshteinDistance) {
+    return 0;
+  }
   const matchingScore = matches.length / Math.min(target.length, query.length);
   const normalizedDistance = distance / Math.max(query.length, target.length);
   const score =


### PR DESCRIPTION
Setting the max Levenshtein distance based on length of the string and omit the strings which exceed the distance in order to show relevant matches.

Before - query: **kind**
<img width="1153" alt="Screenshot 2024-07-26 at 1 50 00 PM" src="https://github.com/user-attachments/assets/54830115-0f04-43f2-aa9b-87543f50744d">

Now
<img width="1237" alt="Screenshot 2024-07-26 at 1 49 43 PM" src="https://github.com/user-attachments/assets/c20c1846-5a74-4055-8a6f-5462ea4c1750">

